### PR TITLE
fix: publiccode url declared

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,6 +1,6 @@
 publiccodeYmlVersion: "0.5"
 name: Tiledesk
-url: https://github.com/Tiledesk/tiledesk-deployment
+url: https://github.com/Tiledesk/tiledesk
 landingURL: https://tiledesk.com/
 releaseDate: 2022-06-15
 platforms:


### PR DESCRIPTION
Unfortunately our cron doesn't follow GitHub redirects, you have to use the current url.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata change to a documentation/config file; no runtime or security impact.
> 
> **Overview**
> Updates `publiccode.yml` to point the project `url` at the canonical `https://github.com/Tiledesk/tiledesk` repository instead of the old `tiledesk-deployment` URL (avoiding reliance on GitHub redirects).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3aa380806180233011b7e0f70ad9c3b44b31f148. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->